### PR TITLE
Add AudioLivenessDetection (on-device PCM replay/liveness detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Deepfake Speech Detection Papers
 
+## Tools & Libraries
+
+| Link | Language | Description |
+| :--- | :--- | :--- |
+| [AudioLivenessDetection](https://github.com/mythkiven/AudioLivenessDetection) | Swift | On-device PCM audio liveness detection — distinguish live microphone speech from recorded replay on iOS/macOS. Zero dependencies, SPM + demo. |
+
 > 最后更新时间: 2026-06-05
 
 | 发布日期 | 文章名 | 第一作者 | 链接 |


### PR DESCRIPTION
Add [AudioLivenessDetection](https://github.com/mythkiven/AudioLivenessDetection) — on-device PCM audio liveness / replay detection for iOS & macOS.

**Why include**
- Lightweight replay detection without ML models or server-side inference
- MIT licensed, CI, technical docs, CLI + iOS SwiftUI demo
- Complements VAD/ASR entries in this list (live mic vs recorded playback)

Maintainer: @mythkiven

Made with [Cursor](https://cursor.com)